### PR TITLE
feat: group N by fields and groups sort supports

### DIFF
--- a/src/Mysql/Builder.php
+++ b/src/Mysql/Builder.php
@@ -46,6 +46,13 @@ class Builder
      */
     public array $groups = [];
 
+    /**
+     * The group N by fields parameter set
+     *
+     * @var int
+     */
+    public int $groupN = 0;
+
     public array $bindings = [
         'select' => [],
         'search' => [],
@@ -130,7 +137,7 @@ class Builder
         $this->search = $search;
 
         if (!empty($this->search)) {
-            if ($this->autoEscaping){
+            if ($this->autoEscaping) {
                 $search = $this->grammar->escapeQueryString($search);
             }
 
@@ -484,6 +491,21 @@ class Builder
     }
 
     /**
+     * enable group N by fields
+     *
+     * @see https://manual.manticoresearch.com/Searching/Grouping#GROUP-BY-multiple-fields-at-once
+     *
+     * @param int $n
+     * @return static
+     */
+    public function groupN(int $n)
+    {
+        $this->groupN = $n;
+
+        return $this;
+    }
+
+    /**
      * Add a facet where clause to the query.
      *
      * @param string $field
@@ -497,7 +519,7 @@ class Builder
     public function facet(string $field, ?string $by = null, ?int $limit = null, ?string $sortBy = null, ?string $direction = 'asc'): Builder
     {
         $type = 'Basic';
-        $by = ! is_null($by) ? $by : $field;
+        $by = !is_null($by) ? $by : $field;
 
         $this->facets[] = compact('type', 'field', 'by', 'limit', 'sortBy', 'direction');
 

--- a/src/Mysql/Builder.php
+++ b/src/Mysql/Builder.php
@@ -519,7 +519,7 @@ class Builder
     public function facet(string $field, ?string $by = null, ?int $limit = null, ?string $sortBy = null, ?string $direction = 'asc'): Builder
     {
         $type = 'Basic';
-        $by = !is_null($by) ? $by : $field;
+        $by = ! is_null($by) ? $by : $field;
 
         $this->facets[] = compact('type', 'field', 'by', 'limit', 'sortBy', 'direction');
 

--- a/src/Mysql/Builder.php
+++ b/src/Mysql/Builder.php
@@ -47,6 +47,12 @@ class Builder
     public array $groups = [];
 
     /**
+     * The groupings sorting for the query
+     * @var array
+     */
+    public array $groupSorts = [];
+
+    /**
      * The group N by fields parameter set
      *
      * @var int
@@ -58,6 +64,7 @@ class Builder
         'search' => [],
         'where' => [],
         'groupBy' => [],
+        'groupSort' => [],
         'options' => [],
         'order' => [],
         'calls' => [],
@@ -506,6 +513,24 @@ class Builder
     }
 
     /**
+     * Sorting inside a group
+     *
+     * @see https://manual.manticoresearch.com/Searching/Grouping#Sorting-inside-a-group
+     *
+     * @param string $column
+     * @param string $direction
+     * @return static
+     */
+    public function groupOrderBy($column, $direction = 'asc')
+    {
+        $this->groupSorts[] = [
+            'column' => $column,
+            'direction' => $direction,
+        ];
+        return $this;
+    }
+
+    /**
      * Add a facet where clause to the query.
      *
      * @param string $field
@@ -519,7 +544,7 @@ class Builder
     public function facet(string $field, ?string $by = null, ?int $limit = null, ?string $sortBy = null, ?string $direction = 'asc'): Builder
     {
         $type = 'Basic';
-        $by = ! is_null($by) ? $by : $field;
+        $by = !is_null($by) ? $by : $field;
 
         $this->facets[] = compact('type', 'field', 'by', 'limit', 'sortBy', 'direction');
 

--- a/src/Mysql/ManticoreGrammar.php
+++ b/src/Mysql/ManticoreGrammar.php
@@ -418,7 +418,7 @@ class ManticoreGrammar extends Grammar
             return '';
         }
 
-        if ($query->groupN > 0) {
+        if ($query->groupN > 1) {
             return 'group ' . $query->groupN . ' by ' . $this->columnize($groups);
         }
 

--- a/src/Mysql/ManticoreGrammar.php
+++ b/src/Mysql/ManticoreGrammar.php
@@ -16,6 +16,7 @@ class ManticoreGrammar extends Grammar
         'search',
         'wheres',
         'groups',
+        'groupSorts',
         'orders',
         'limit',
         'offset',
@@ -422,6 +423,15 @@ class ManticoreGrammar extends Grammar
         }
 
         return 'group by ' . $this->columnize($groups);
+    }
+
+    protected function compileGroupSorts(Builder $query, array $orders)
+    {
+        if (empty($orders)) {
+            return '';
+        }
+
+        return 'within group order by ' . implode(', ', $this->compileOrdersToArray($query, $orders));
     }
 
     /**

--- a/src/Mysql/ManticoreGrammar.php
+++ b/src/Mysql/ManticoreGrammar.php
@@ -418,7 +418,7 @@ class ManticoreGrammar extends Grammar
         }
 
         if ($query->groupN > 0) {
-            return 'group ' . $query->groupN . 'by ' . $this->columnize($groups);
+            return 'group ' . $query->groupN . ' by ' . $this->columnize($groups);
         }
 
         return 'group by ' . $this->columnize($groups);

--- a/src/Mysql/ManticoreGrammar.php
+++ b/src/Mysql/ManticoreGrammar.php
@@ -417,6 +417,10 @@ class ManticoreGrammar extends Grammar
             return '';
         }
 
+        if ($query->groupN > 0) {
+            return 'group ' . $query->groupN . 'by ' . $this->columnize($groups);
+        }
+
         return 'group by ' . $this->columnize($groups);
     }
 


### PR DESCRIPTION
https://manual.manticoresearch.com/Searching/Grouping#Give-me-N-rows
https://manual.manticoresearch.com/Searching/Grouping#Sorting-inside-a-group

usage

# group N by column
use `$builder->groupN(int $num)` to enable `group N by fields` (effective when $num is greater than 0)

```php
Products::search($keywords, fn($builder) => $builder->groupN(3)->groupBy('field-a', 'field-b'))
->get();

// select * from products where match (keywords) group 3 by fielda, fieldb
```

```php
// normally group filter
Products::search($keywords, fn($builder) => $builder->groupBy('field-a', 'field-b'))
->get();

// select * from products where match (keywords) group by fielda, fieldb
```

# groups sort

sorting in groups

```php
Products::search($keywords, fn($builder) => $builder->groupOrderBy($column, $direction = 'asc'))
->get();

// select * from products where match (keywords) group 3 by fielda, fieldb
```


compatible with mysql mode only