### PR TITLE
Support for specifying the priority of an orders condition in `queryCallback`.

### DIFF
--- a/src/Mysql/Builder.php
+++ b/src/Mysql/Builder.php
@@ -435,45 +435,71 @@ class Builder
 
     /**
      * Add an "order" for the search query.
+     *
+     * @param string $column
+     * @param string $direction
+     * @param bool $prepend
+     *
+     * @return static
      */
-    public function orderBy(string $column, string $direction = 'asc'): Builder
+    public function orderBy(string $column, string $direction = 'asc', bool $prepend = false): Builder
     {
-        $this->orders[] = [
+        $func = $prepend ? 'array_unshift' : 'array_push';
+
+        $func($this->orders, [
             'column' => $column,
             'direction' => strtolower($direction) == 'asc' ? 'asc' : 'desc',
-        ];
+        ]);
 
         return $this;
     }
 
     /**
      * Put the query's results in random order.
+     *
+     * @param int|null $seed
+     * @param bool $prepend
+     *
+     * @return static
      */
-    public function inRandomOrder(?int $seed = null)
+    public function inRandomOrder(?int $seed = null, bool $prepend = false)
     {
         if (!is_null($seed)) {
             $this->option('rand_seed', $seed);
         }
 
-        return $this->orderByRaw($this->grammar->compileRandom());
+        return $this->orderByRaw($this->grammar->compileRandom(), [], $prepend);
     }
 
     /**
      * Put the query's results in weight order.
+     *
+     * @param string $direction
+     * @param bool $prepend
+     *
+     * @return static
      */
-    public function inWeightOrder(string $direction = 'asc')
+    public function inWeightOrder(string $direction = 'asc', bool $prepend = false)
     {
-        return $this->orderByRaw($this->grammar->compileWeight($direction));
+        return $this->orderByRaw($this->grammar->compileWeight($direction), [], $prepend);
     }
 
     /**
      * Add a raw "order by" clause to the query.
+     *
+     * @param string $sql
+     * @param array $bindings
+     * @param bool $prepend
+     *
+     * @return static
      */
-    public function orderByRaw(string $sql, array $bindings = []): Builder
+    public function orderByRaw(string $sql, array $bindings = [], bool $prepend = false): Builder
     {
         $type = 'Raw';
 
-        $this->orders[] = compact('type', 'sql');
+        $func = $prepend ? 'array_unshift' : 'array_push';
+
+        $func($this->orders, compact('type', 'sql'));
 
         $this->addBinding($bindings, 'order');
 


### PR DESCRIPTION
Support for specifying the priority of an orders condition in `queryCallback`.

```php
// search products and order by  search result weight and order of adding products
Products:search($keyword, function ($builder) {
    return $builder->inWeightOrder('desc');
})->orderBy('id','desc')->get();

// expected: select * from `products` where match(?) order by  weight() desc,`id` desc 
// actually: select * from `products` where match(?) order by `id` desc, weight() desc
```

this actually results in the sort not being ordered by relevance

It is of course possible to use the `orderBy` method in `queryCallback`, but this restricts the `queryCallback` to having to splice all the ordering rules completely, which may not work in the following scenarios:

```php
$search = Products:search($keyword, function ($builder) {
    return $builder->inWeightOrder('desc');
});

if ($request->input('newest')) {
    $search->orderBy('id','desc');
}
if ($request->input('cheapest')) {
    $search->orderBy('price', 'asc');
}

.....

$search->get();

```

This PR adds the `prepend` parameter to the `orderBy`, `orderByRaw` and `inWeightOrder` methods, indicating whether or not the parameter is added to the `Builder::$orders` first.

```php
Products:search($keyword, function ($builder) {
    return $builder->inWeightOrder('desc', true);
})->orderBy('id','desc')->get();
// sql: select * from `products` where match(?) order by  weight() desc,`id` desc 
```