### PR TITLE
Fixed problema with db prefix

### DIFF
--- a/src/Mysql/ManticoreGrammar.php
+++ b/src/Mysql/ManticoreGrammar.php
@@ -27,7 +27,13 @@ class ManticoreGrammar extends Grammar
         'facets',
         'meta'
     ];
-
+    
+    public function wrapTable($table, $prefix = null)
+    {
+      $prefix = '';
+        
+      return parent::wrapTable($table,$prefix);
+    }
     /**
      * Compile a select query into SQL.
      */


### PR DESCRIPTION
Fixed #60 problema if DATABASE have prefix 
 SQLSTATE[42000]: Syntax error or access violation: 1064 table 'prefixDB_table' absent